### PR TITLE
Feat: Exclude QtQuickControls2

### DIFF
--- a/examples/BarcodeEncoder/main.qml
+++ b/examples/BarcodeEncoder/main.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick.Controls.Basic
 import QtQuick.Layouts 1.3
 //import QtQuick.Dialogs 1.3
 import Qt.labs.platform 1.1

--- a/examples/QZXingLive/main.qml
+++ b/examples/QZXingLive/main.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.5
 import QtQuick.Window 2.0
-import QtQuick.Controls 2.0
+import QtQuick.Controls.Basic
 import QtQuick.Layouts 1.1
 import QtMultimedia 5.5
 

--- a/examples/QZXingLive/main_qt6_2.qml
+++ b/examples/QZXingLive/main_qt6_2.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.5
 import QtQuick.Window 2.0
-import QtQuick.Controls 2.0
+import QtQuick.Controls.Basic
 import QtQuick.Layouts 1.1
 import QtMultimedia
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 project(QZXing)
 
-find_package(Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt5 COMPONENTS Gui REQUIRED)
-find_package(Qt5 COMPONENTS Multimedia )
-find_package(Qt5 REQUIRED Svg Quick QuickControls2)
+find_package(Qt6 COMPONENTS Core Gui Svg Quick QuickControls2 REQUIRED)
 
 SET(BIGINT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zxing/bigint)
 SET(WIN32_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/zxing/win32/zxing)
@@ -65,18 +62,18 @@ add_subdirectory(zxing/bigint)
 
 add_subdirectory(zxing/zxing)
 
-target_link_libraries(qzxing Qt5::Core Qt5::Gui)
+target_link_libraries(qzxing Qt6::Core Qt6::Gui)
 
 if(QZXING_MULTIMEDIA)
-    target_link_libraries(qzxing Qt5::Multimedia)
+    target_link_libraries(qzxing Qt6::Multimedia)
     target_compile_definitions(qzxing PUBLIC -DQZXING_MULTIMEDIA)
 endif(QZXING_MULTIMEDIA)
 
 if(QZXING_USE_QML)
     target_link_libraries(qzxing
-        Qt5::Svg
-        Qt5::Quick
-        Qt5::QuickControls2)
+        Qt6::Svg
+        Qt6::Quick
+        Qt6::QuickControls2)
     target_compile_definitions(qzxing PUBLIC -DQZXING_QML)
 endif(QZXING_USE_QML)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.24)
 project(QZXing)
 
 find_package(Qt6 COMPONENTS Core Gui Svg Quick QuickControls2 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 project(QZXing)
 
-find_package(Qt6 COMPONENTS Core Gui Svg Quick QuickControls2 REQUIRED)
+find_package(Qt6 COMPONENTS Core Gui Svg Quick REQUIRED)
 
 SET(BIGINT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zxing/bigint)
 SET(WIN32_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/zxing/win32/zxing)
@@ -72,8 +72,7 @@ endif(QZXING_MULTIMEDIA)
 if(QZXING_USE_QML)
     target_link_libraries(qzxing
         Qt6::Svg
-        Qt6::Quick
-        Qt6::QuickControls2)
+        Qt6::Quick)
     target_compile_definitions(qzxing PUBLIC -DQZXING_QML)
 endif(QZXING_USE_QML)
 


### PR DESCRIPTION
## Remove QtQuickControls2 dependency and unqualified Controls imports

  ### What

  - Drop `QuickControls2` from `find_package(Qt6 ...)` and from qzxing's link
    libraries in `src/CMakeLists.txt`. Nothing in the library code uses it —
    the dependency was gratuitous.
  - Change the unqualified `import QtQuick.Controls 2.0` in the three example
    apps (`QZXingLive`, `BarcodeEncoder`) to `import QtQuick.Controls.Basic`.

  ### Why
  
  qzxing is vendored as a git submodule in venus-gui-v2. For statically linked
  builds (WebAssembly), Qt's `qt_import_qml_plugins()` runs `qmlimportscanner`
  over the whole source tree — including this submodule's `examples/`
  directory, even though it is never built. An unqualified
  `import QtQuick.Controls` anywhere in the scanned tree forces **every**
  Controls style plugin (Basic, Material, Fusion, Universal, Imagine,
  FluentWinUI3, plus native style stubs) into the final binary.

  Importing the Basic style explicitly lets the scanner link only that style.
  Measured on the venus-gui-v2 WASM build (together with the matching
  gui-v2-side import fix): **−4.1 MB uncompressed (−11.6%), −1.75 MB gzipped
  (−11.1%)**.

  The `Qt6::QuickControls2` link removal additionally means qzxing no longer
  drags the Controls C++ module into any consumer that links the library.

  ### Note

  `QtQuick.Controls.Basic` is a Qt 6 module, so the Qt 5 variant of the
  QZXingLive example would no longer load. This fork is used with Qt 6 only.